### PR TITLE
Potential fix for code scanning alert no. 56: Incomplete URL substring sanitization

### DIFF
--- a/offscreen.ts
+++ b/offscreen.ts
@@ -163,12 +163,26 @@ function detectPageCategory(url: string, title: string): string {
     return 'shopping';
   }
 
+  const getHostname = (rawUrl: string): string => {
+    try {
+      return new URL(rawUrl).hostname.toLowerCase();
+    } catch {
+      return '';
+    }
+  };
+
+  const urlMatchesDomain = (rawUrl: string, domain: string): boolean => {
+    const host = getHostname(rawUrl);
+    const normalizedDomain = domain.toLowerCase();
+    return host === normalizedDomain || host.endsWith(`.${normalizedDomain}`);
+  };
+
   // Search
   if (
-    urlLower.includes('google.com') ||
-    urlLower.includes('bing.com') ||
-    urlLower.includes('duckduckgo.com') ||
-    urlLower.includes('yahoo.com')
+    urlMatchesDomain(url, 'google.com') ||
+    urlMatchesDomain(url, 'bing.com') ||
+    urlMatchesDomain(url, 'duckduckgo.com') ||
+    urlMatchesDomain(url, 'yahoo.com')
   ) {
     return 'search';
   }


### PR DESCRIPTION
Potential fix for [https://github.com/fujiDevv/context-aware-browser-pet/security/code-scanning/56](https://github.com/fujiDevv/context-aware-browser-pet/security/code-scanning/56)

General fix: stop checking domain substrings in the entire URL string. Instead, parse the URL and compare against the `hostname`, allowing exact match or proper subdomain suffix match (`host === domain || host.endsWith('.' + domain)`).

Best concrete fix in `offscreen.ts`: introduce a small helper that safely extracts hostname and performs domain matching, then update the highlighted search-domain checks (and keep behavior otherwise unchanged). This avoids false matches in path/query and prevents prefix/suffix hostname tricks.

Changes needed:
- In `offscreen.ts`, add helper functions near the categorization logic:
  - `getHostname(url: string): string`
  - `urlMatchesDomain(url: string, domain: string): boolean`
- Replace `urlLower.includes('google.com' | 'bing.com' | 'duckduckgo.com' | 'yahoo.com')` with `urlMatchesDomain(url, '...')`.
- No new dependencies required; use built-in `URL`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
