### PR TITLE
Potential fix for code scanning alert no. 61: DOM text reinterpreted as HTML

### DIFF
--- a/options/options.ts
+++ b/options/options.ts
@@ -1028,7 +1028,23 @@ const COSTUMES_METADATA = [
 
 function getMascotSvgName(mood: string, costume: string): string {
   const idleStates = ['happy', 'waving', 'smile', 'idle-living'];
-  if (!idleStates.includes(mood)) return mood;
+  const allowedSvgNames = new Set([
+    'happy',
+    'waving',
+    'smile',
+    'idle-living',
+    'christmas',
+    'halloween',
+    'summer',
+    'detective',
+    'magic',
+    'rainbow'
+  ]);
+  const normalizedMood = mood.trim().toLowerCase();
+
+  if (!idleStates.includes(normalizedMood)) {
+    return allowedSvgNames.has(normalizedMood) ? normalizedMood : 'happy';
+  }
 
   const costumeMap: Record<string, string> = {
     christmas: 'christmas',
@@ -1038,7 +1054,8 @@ function getMascotSvgName(mood: string, costume: string): string {
     wizard: 'magic',
     party: 'rainbow'
   };
-  return costumeMap[costume] || mood;
+  const mapped = costumeMap[costume] || normalizedMood;
+  return allowedSvgNames.has(mapped) ? mapped : 'happy';
 }
 
 function renderWardrobe(stats: PetStats | undefined, activeCostumeId: string) {


### PR DESCRIPTION
Potential fix for [https://github.com/fujiDevv/context-aware-browser-pet/security/code-scanning/61](https://github.com/fujiDevv/context-aware-browser-pet/security/code-scanning/61)

General fix: avoid deriving security-sensitive values (like resource URLs) from DOM text; instead use strict allowlists and fallback defaults for unknown values.

Best fix here (without changing behavior intent): in `options/options.ts`, tighten `getMascotSvgName` so it never returns arbitrary `mood`. Only return known safe SVG basenames; otherwise fall back to `'happy'`. This preserves costume handling and existing known moods while blocking tainted/unexpected text from becoming part of the path.

Changes needed:
- Edit `getMascotSvgName` (around lines 1029–1042).
- Add a local allowlist (`Set`) of permitted mascot SVG names.
- Normalize `mood` input and only return values in the allowlist.
- Keep costume map logic as-is for idle states.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
